### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -26,7 +26,7 @@ calibration	KEYWORD2
 getXY	KEYWORD2
 getRZ	KEYWORD2
 getRaw	KEYWORD2
-transform KEYWORD2
+transform	KEYWORD2
 setMeasure	KEYWORD2
 setValidRawRange	KEYWORD2
 setMeasureWait	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords